### PR TITLE
Cater for subfolder installs in request

### DIFF
--- a/assets/extension_downloader.js
+++ b/assets/extension_downloader.js
@@ -12,7 +12,8 @@
 	var download = function () {
 		wrap.addClass('loading');
 		input.attr('disabled', 'disabled').blur();
-		$.post('/symphony/extension/extension_downloader/download/', {
+		url = Symphony.Context.get('root');
+		$.post(url+'/symphony/extension/extension_downloader/download/', {
 				q: input.val()
 			}, function (data) {
 			if (data.success) {


### PR DESCRIPTION
Looking at this locally it wasn't working and remembered I was in a subfolder so needed to add a reference to the subfolder in the request url.
