### PR TITLE
Path URL and XPath edits for 2.6.7 compatibility

### DIFF
--- a/assets/extension_downloader.js
+++ b/assets/extension_downloader.js
@@ -7,10 +7,10 @@
 	"use strict";
 	
 	var SYM_URL = Symphony.Context.get('symphony');
-	var BASE_URL = SYM_URL + 'extension/extension_downloader/';
+	var BASE_URL = SYM_URL + '/extension/extension_downloader/';
 	var DOWNLOAD_URL = BASE_URL + 'download/';
 	var SEARCH_URL = BASE_URL + 'search/';
-	var EXTENSIONS_URL = SYM_URL + 'system/extensions/';
+	var EXTENSIONS_URL = SYM_URL + '/system/extensions/';
 	
 	var COMPATIBLE_ONLY = true;
 	

--- a/content/content.download.php
+++ b/content/content.download.php
@@ -133,8 +133,9 @@
 		private function searchExtension($query) {
 			
 			$xml = SymphonyExtensions::getExtensionAsXML($query);
+            $xml = $xml[0];
 			
-			$this->extensionHandle = $xml->xpath('/response/extension/@id');
+			$this->extensionHandle = $xml->xpath('@id');
 			
 			if (empty($this->extensionHandle)) {
 				throw new Exception(__("Could not find extension handle"));
@@ -142,7 +143,7 @@
 				$this->extensionHandle = (string)$this->extensionHandle[0];
 			}
 			
-			$this->downloadUrl = $xml->xpath("/response/extension/link[@rel='github:zip']/@href");
+			$this->downloadUrl = $xml->xpath("link[@rel='github:zip']/@href");
 			
 			if (empty($this->downloadUrl)) {
 				throw new Exception(__("Could not find extension handle"));


### PR DESCRIPTION
Hi, 

I had to make a few fixes to get this working on 2.6.7 : -

1. Two of the URLs were missing leading slashes (`SYM_URL` didn't have a trailing one) so the AJAX calls were 404'ing

2. `SymphonyExtensions::getExtensionAsXML` was returning an array of SimpleXML objects, not the object itself, so I simply selected the first with an overwrite `$xml = $xml[0];` to allow later code access to the object.

3. The SimpleXML object had already selected the `/response/extension/` node in `SymphonyExtensions::getExtensionAsXML` so the XPath in `searchExtension()` was failing.

**Additional** - I had to disable XSRF in `config.php` by setting `'enable_xsrf' => 'no',` otherwise the AJAX calls always return 403 (Forbidden). Is there a better fix / workaround for this? (I don't like having to disable XSRF even in development, though can of course be enabled for production in productions' `config.php`).

With these three edits (and disabling XSRF) I was able to search and download extensions, didn't encounter any other errors, all works as expected.

Thanks for the great extension, makes grabbing new extensions so much simpler!